### PR TITLE
Updating the SWAP alogithm

### DIFF
--- a/R/PerSIMPER.R
+++ b/R/PerSIMPER.R
@@ -130,7 +130,26 @@ library(dplyr)
       v <- T
       dp4 <- permatfull(matrixSIMP, fixedmar = "columns", mtype = dataTYPE, times = 1)  #prab
       for(j in 1:length(dp4$perm[[1]][,2])) {
-        if(sum(dp4$perm[[1]][j,]) == 0){v <- FALSE}
+        if(sum(dp4$perm[[1]][j,]) == 0){v <- FALSE
+             
+        if(SWAPcount > 50)
+          {
+          ### Looking for cells to swap from rich taxa and rich locality to empty locality
+          tempColSum <- apply(dp4$perm[[1]], 2, sum)
+          tempHigh_Col <- which(apply(dp4$perm[[1]], 2, sum) > median(tempColSum))
+          tempMoove <- sample(tempHigh_Col, 1)
+          tempColSel <- dp4$perm[[1]][,tempMoove]
+          tempCel <-  which(tempColSel  == 1)
+          tempHigh_Row <- which(apply(dp4$perm[[1]][tempCel,], 1, sum) > median(apply(dp4$perm[[1]][tempCel,], 1, sum))) 
+          tempMoove2 <- sample(tempHigh_Row, 1)
+          
+          #### Swapping
+          dp4$perm[[1]][tempCel[tempMoove2], tempMoove] <- 0
+          dp4$perm[[1]][j,tempMoove] <- 1
+          v <- TRUE
+          }                                  
+                                       
+         }
         }
       if(v == TRUE) break
       }


### PR DESCRIPTION
Fixed columns algorithm can generate empty rows when used matrix has a very low col/row ratio. Can generate infinite loop or very slow permutation. Now changed to follow a different algorithm after 50 failure (i.e. permuted matrix with empty rows).